### PR TITLE
Fixes vanBassum#8, use another way to hide the window.

### DIFF
--- a/Editor/HeartbeatCollector.cs
+++ b/Editor/HeartbeatCollector.cs
@@ -173,6 +173,7 @@ namespace WakaTime
                 process.Start();
 
                 string branchname = process.StandardOutput.ReadLine();
+                process.Kill();
                 return branchname;
             }
             catch(Exception ex)

--- a/Editor/HeartbeatCollector.cs
+++ b/Editor/HeartbeatCollector.cs
@@ -163,6 +163,7 @@ namespace WakaTime
                 startInfo.UseShellExecute = false;
                 startInfo.WorkingDirectory = workingDir;
                 startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                startInfo.CreateNoWindow = true;
                 startInfo.RedirectStandardInput = true;
                 startInfo.RedirectStandardOutput = true;
                 startInfo.Arguments = "rev-parse --abbrev-ref HEAD";


### PR DESCRIPTION
I'm not sure why this is not worked for Windows Terminal,
```c#
startInfo.WindowStyle = ProcessWindowStyle.Hidden;
```
but using the following code, it works and returns proper branch name:
```c#
startInfo.CreateNoWindow = true;
```
I read docs from Microsoft:
```c#
// This code assumes the process you are starting will terminate itself.
// Given that it is started without a window so you cannot terminate it
// on the desktop, it must terminate itself or you can do it programmatically
// from this application using the Kill method.
```
So I also added this code after fetch the branch name to ensure it will be terminated:
```c#
process.Kill();
```