### PR TITLE
Fixed missing 'using' in previous pull request

### DIFF
--- a/Editor/Collectors/HeartbeatCollector.cs
+++ b/Editor/Collectors/HeartbeatCollector.cs
@@ -1,6 +1,7 @@
 ﻿#if (UNITY_EDITOR)
 
 using System;
+using System.Globalization;
 using System.IO;
 using UnityEditor;
 using UnityEditor.SceneManagement;


### PR DESCRIPTION
Sorry, it appears that I did not add the correct import to the last pull request, and that the previous merge broke the release