### PR TITLE
fix: GitCli running in MainThread and block

### DIFF
--- a/Editor/Git/GitCliClient.cs
+++ b/Editor/Git/GitCliClient.cs
@@ -3,45 +3,60 @@
 
 using System.Diagnostics;
 using System;
+using System.Threading.Tasks;
 
 namespace Wakatime
 {
     public class GitCliClient : IGitClient
     {
+        private TaskCompletionSource<string> _getBranchNameTaskSource;
+        
         private Logger Logger { get; }
         public GitCliClient(Logger logger)
         {
             Logger = logger;
         }
 
-        public string GetBranchName(string workingDir)
+        public ValueTask<string> GetBranchNameAsync(string workingDir)
         {
-            try
+            if (_getBranchNameTaskSource != null)
+                return new ValueTask<string>(_getBranchNameTaskSource.Task);
+
+            _getBranchNameTaskSource = new TaskCompletionSource<string>();
+            var task = _getBranchNameTaskSource.Task;
+
+            Task.Run(() =>
             {
-                ProcessStartInfo startInfo = new ProcessStartInfo("git"); //No .exe, I assume this work on linux and macos.
+                try
+                {
+                    ProcessStartInfo startInfo = new ProcessStartInfo("git"); //No .exe, I assume this work on linux and macos.
 
-                startInfo.UseShellExecute = false;
-                startInfo.WorkingDirectory = workingDir;
-                startInfo.WindowStyle = ProcessWindowStyle.Hidden;
-                startInfo.RedirectStandardInput = true;
-                startInfo.RedirectStandardOutput = true;
-                startInfo.CreateNoWindow = true;
-                startInfo.Arguments = "rev-parse --abbrev-ref HEAD";
+                    startInfo.UseShellExecute = false;
+                    startInfo.WorkingDirectory = workingDir;
+                    startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                    startInfo.RedirectStandardInput = true;
+                    startInfo.RedirectStandardOutput = true;
+                    startInfo.CreateNoWindow = true;
+                    startInfo.Arguments = "rev-parse --abbrev-ref HEAD";
 
-                using Process process = new Process();
-                process.StartInfo = startInfo;
-                process.Start();
+                    using Process process = new Process();
+                    process.StartInfo = startInfo;
+                    process.Start();
 
-                string branchname = process.StandardOutput.ReadLine();
-                return branchname;
-            }
-            catch (Exception ex)
-            {
-                //Todo, figure out if git exists on this machine.
-                //Also, figure out if this is even a git repo.
-                Logger.Log(LogLevels.Warning, $"Couln't determine branchname, is git installed?\n {ex.Message}");
-            }
-            return null;
+                    string branchname = process.StandardOutput.ReadLine();
+                    _getBranchNameTaskSource.SetResult(branchname);
+                }
+                catch (Exception ex)
+                {
+                    //Todo, figure out if git exists on this machine.
+                    //Also, figure out if this is even a git repo.
+                    Logger.Log(LogLevels.Warning, $"Couln't determine branchname, is git installed?\n {ex.Message}");
+                    // _getBranchNameTaskSource.SetException(ex);
+                    _getBranchNameTaskSource.SetResult(null);
+                }
+            });
+
+            return new ValueTask<string>(task);
         }
     }
 }

--- a/Editor/Git/IGitClient.cs
+++ b/Editor/Git/IGitClient.cs
@@ -1,11 +1,13 @@
-﻿#if (UNITY_EDITOR)
+﻿using System.Threading.Tasks;
+
+#if (UNITY_EDITOR)
 
 
 namespace Wakatime
 {
     public interface IGitClient
     {
-        string GetBranchName(string path);
+        ValueTask<string> GetBranchNameAsync(string path);
     }
 }
 


### PR DESCRIPTION
I don't know why IO performance SO BAD on my PC.
<img width="2560" height="1380" alt="dcea8c8d1a4c3846c58c07fae8eae039" src="https://github.com/user-attachments/assets/036106b0-f0a4-4b9b-804b-a987dfa40c2c" />

This pull request refactors the heartbeat collection and Git branch detection logic to use asynchronous methods, improving performance and reliability when interacting with Git. The main changes include converting synchronous Git branch lookups to asynchronous calls, updating the `IGitClient` interface, and refactoring the heartbeat creation workflow to handle async operations and errors more gracefully.

**Asynchronous Git branch detection and heartbeat creation:**

* Refactored `IGitClient` interface to replace `GetBranchName` with an asynchronous `GetBranchNameAsync` method, affecting all implementations.
* Updated both `GitCliClient` and `GitFileIOClient` to provide async implementations of `GetBranchNameAsync`, using `TaskCompletionSource` and background tasks to avoid blocking the main thread. [[1]](diffhunk://#diff-bffe35f5876d19c30624ca9ae40aa5e54f4f8c75cc2605efd499234872aa0ff8R6-R28) [[2]](diffhunk://#diff-bffe35f5876d19c30624ca9ae40aa5e54f4f8c75cc2605efd499234872aa0ff8L36-R59) [[3]](diffhunk://#diff-80c8b71ba6e2e6ce03b28b221b481ccbeb704fa871b24b790da25420f3661cf5R6-R37)
* Modified `HeartbeatCollector` to use an async `CreateHeartbeatAsync` method and a new `CreateAndThrowHeartbeat` helper, ensuring heartbeats are created and sent asynchronously, with improved error handling and support for additional processing via callbacks.

**Code modernization and reliability:**

* Updated file IO in `GitFileIOClient` to use `File.ReadAllTextAsync` for non-blocking file reads when detecting the current Git branch.
